### PR TITLE
fix: align HTML preview hour labels with the live card

### DIFF
--- a/docs/preview/card-preview.html
+++ b/docs/preview/card-preview.html
@@ -132,11 +132,12 @@
       if (deg > 90 || deg < -90) deg += 180;
       return deg;
     }
-    function textEl(i, n, r, str, size, fill, dy) {
+    function textEl(i, n, r, str, size, fill) {
       const p = textPos(i, n, r);
-      const y = p.y + (dy || 3);
-      return `<text x="${p.x}" y="${y}" text-anchor="middle" font-size="${size}" font-weight="700"
-        transform="rotate(${rot(i, n)} ${p.x} ${y})" fill="${fill}" style="pointer-events:none">${str}</text>`;
+      return `<text x="${p.x}" y="${p.y}" text-anchor="middle" dominant-baseline="central"
+        alignment-baseline="middle" font-size="${size}" font-weight="700"
+        transform="rotate(${rot(i, n)} ${p.x} ${p.y})" fill="${fill}"
+        style="pointer-events:none; user-select:none; direction:ltr">${str}</text>`;
     }
     function toggle(h, minutes) {
       const allOn = minutes.every((m) => has(h, m));
@@ -156,28 +157,38 @@
         html += `<line x1="${CX + R_IN * Math.cos(a)}" y1="${CY + R_IN * Math.sin(a)}"
           x2="${CX + R_OUT * Math.cos(a)}" y2="${CY + R_OUT * Math.sin(a)}" stroke="${STROKE}"/>`;
       }
-      for (let h = 0; h < 24; h++) {
-        for (const band of BANDS) {
-          const active = has(h, band.m);
-          const sel = mode === 15 && selected === h;
-          const fill = active ? GREEN : WHITE;
-          const click = mode === 15
-            ? `data-h="${h}" data-m="${band.m}"`
-            : `data-h="${h}" data-m="${band.m <= 15 ? 0 : 30}"`;
-          html += `<path d="${sector(h, 24, band.a, band.b)}" fill="${fill}" stroke="${sel ? SELECT : STROKE}"
-            stroke-width="${sel ? 2.5 : 1}" ${click}/>`;
-          if (sel && band.m !== 0) {
-            html += textEl(h, 24, (band.a + band.b) / 2, String(band.m), 9, active ? "#fff" : INK, 2);
+      if (mode === 15) {
+        for (let h = 0; h < 24; h++) {
+          for (const band of BANDS) {
+            const active = has(h, band.m);
+            const sel = selected === h;
+            html += `<path d="${sector(h, 24, band.a, band.b)}" fill="${active ? GREEN : WHITE}"
+              stroke="${sel ? SELECT : STROKE}" stroke-width="${sel ? 2.5 : 1}"
+              data-h="${h}" data-m="${band.m}"/>`;
+            if (sel && band.m !== 0) {
+              html += textEl(h, 24, (band.a + band.b) / 2, String(band.m), 9, active ? "#fff" : INK);
+            }
           }
         }
-      }
-      for (let h = 0; h < 24; h++) {
-        if (mode === 30) {
-          html += textEl(h, 24, (R_MID + R_OUT) / 2, pad(h) + ":00", 11, has(h, 0) && has(h, 15) ? "#fff" : INK, 3);
-          html += textEl(h, 24, (R_IN + R_MID) / 2, pad(h) + ":30", 9, has(h, 30) && has(h, 45) ? "#fff" : MUTED, 2);
-        } else {
+        const outerLabelR = (BANDS[0].a + BANDS[0].b) / 2;
+        for (let h = 0; h < 24; h++) {
           const allOn = [0, 15, 30, 45].every((m) => has(h, m));
-          html += textEl(h, 24, (R_MID + R_OUT) / 2, pad(h), 11, allOn ? "#fff" : INK, 3);
+          html += textEl(h, 24, outerLabelR, pad(h), 11, allOn ? "#fff" : INK);
+        }
+      } else {
+        const rings = [
+          { pair: 0, minutes: [0, 15], a: R_MID, b: R_OUT },
+          { pair: 30, minutes: [30, 45], a: R_IN, b: R_MID }
+        ];
+        for (let h = 0; h < 24; h++) {
+          for (const ring of rings) {
+            const active = ring.minutes.every((m) => has(h, m));
+            const fill = active ? GREEN : (ring.pair === 0 ? WHITE : "#f8f9fa");
+            html += `<path d="${sector(h, 24, ring.a, ring.b)}" fill="${fill}" stroke="${STROKE}"
+              stroke-width="1" data-h="${h}" data-m="${ring.pair}"/>`;
+          }
+          html += textEl(h, 24, (R_MID + R_OUT) / 2, pad(h) + ":00", 11, has(h, 0) && has(h, 15) ? "#fff" : INK);
+          html += textEl(h, 24, (R_IN + R_MID) / 2, pad(h) + ":30", 9, has(h, 30) && has(h, 45) ? "#fff" : MUTED);
         }
       }
       const nowBand = BANDS.find((b) => b.m === now.m);
@@ -195,7 +206,7 @@
       document.getElementById("stage").innerHTML = html;
       document.getElementById("hint").textContent = mode === 15
         ? "Tap an hour to select it (blue), then tap a quarter (00 / 15 / 30 / 45). Red = now."
-        : "Tap :00 to cover the first half-hour, :30 for the second. Red = now.";
+        : "Outer ring = the hour. Inner ring = the half-hour. Red = now.";
       document.getElementById("stage").querySelector("svg").addEventListener("click", (ev) => {
         const path = ev.target.closest("path");
         if (!path || path.dataset.h === undefined) return;
@@ -203,7 +214,13 @@
         const m = Number(path.dataset.m);
         if (mode === 15) {
           if (selected !== h) selected = h;
-          else toggle(h, [m]);
+          else if (m === 0) {
+            const allOn = [0, 15, 30, 45].every((min) => has(h, min));
+            if (!allOn) toggle(h, [0, 15, 30, 45]);
+            else toggle(h, [0]);
+          } else {
+            toggle(h, [m]);
+          }
         } else {
           toggle(h, m === 0 ? [0, 15] : [30, 45]);
         }

--- a/docs/preview/generate-preview.py
+++ b/docs/preview/generate-preview.py
@@ -85,53 +85,50 @@ def clock(on: set[tuple[int, int]], mode: int, selected: int | None, now_h: int,
             f'<line x1="{x1:.2f}" y1="{y1:.2f}" x2="{x2:.2f}" y2="{y2:.2f}" '
             f'stroke="{STROKE}" stroke-width="1"/>'
         )
-    for hour in range(24):
-        for minute, inner, outer in BANDS:
-            active = (hour, minute) in on
-            fill = GREEN if active else (WHITE if minute == 0 or mode == 15 else "#f8f9fa")
-            selected_hour = mode == 15 and selected == hour
-            stroke = SELECT if selected_hour else STROKE
-            width = 2.5 if selected_hour else 1
-            parts.append(
-                f'<path d="{sector(hour, 24, inner, outer)}" fill="{fill}" '
-                f'stroke="{stroke}" stroke-width="{width}"/>'
-            )
-            if selected_hour and minute != 0:
-                tx, ty = text_pos(hour, 24, (inner + outer) / 2)
-                fill_t = "#ffffff" if active else INK
-                rdeg = rot(hour, 24)
+    def label(hour: int, radius: float, text: str, size: int, fill: str) -> None:
+        tx, ty = text_pos(hour, 24, radius)
+        rdeg = rot(hour, 24)
+        parts.append(
+            f'<text x="{tx:.2f}" y="{ty:.2f}" text-anchor="middle" '
+            f'dominant-baseline="central" alignment-baseline="middle" font-size="{size}" '
+            f'font-weight="700" transform="rotate({rdeg:.2f} {tx:.2f} {ty:.2f})" '
+            f'style="direction:ltr" fill="{fill}">{text}</text>'
+        )
+
+    if mode == 15:
+        for hour in range(24):
+            for minute, inner, outer in BANDS:
+                active = (hour, minute) in on
+                selected_hour = selected == hour
                 parts.append(
-                    f'<text x="{tx:.2f}" y="{ty + 2:.2f}" text-anchor="middle" font-size="9" '
-                    f'font-weight="700" transform="rotate({rdeg:.2f} {tx:.2f} {ty + 2:.2f})" '
-                    f'fill="{fill_t}">{minute}</text>'
+                    f'<path d="{sector(hour, 24, inner, outer)}" '
+                    f'fill="{GREEN if active else WHITE}" '
+                    f'stroke="{SELECT if selected_hour else STROKE}" '
+                    f'stroke-width="{2.5 if selected_hour else 1}"/>'
                 )
-    for hour in range(24):
-        if mode == 30:
-            hour_on = all((hour, minute) in on for minute in (0, 15))
-            tx, ty = text_pos(hour, 24, (R_MID + R_OUT) / 2)
-            rdeg = rot(hour, 24)
-            parts.append(
-                f'<text x="{tx:.2f}" y="{ty + 3:.2f}" text-anchor="middle" font-size="11" '
-                f'font-weight="700" transform="rotate({rdeg:.2f} {tx:.2f} {ty + 3:.2f})" '
-                f'fill="{"#ffffff" if hour_on else INK}">{pad(hour)}:00</text>'
-            )
-            half_on = all((hour, minute) in on for minute in (30, 45))
-            tx, ty = text_pos(hour, 24, (R_IN + R_MID) / 2)
-            rdeg = rot(hour, 24)
-            parts.append(
-                f'<text x="{tx:.2f}" y="{ty + 2:.2f}" text-anchor="middle" font-size="9" '
-                f'font-weight="700" transform="rotate({rdeg:.2f} {tx:.2f} {ty + 2:.2f})" '
-                f'fill="{"#ffffff" if half_on else MUTED}">{pad(hour)}:30</text>'
-            )
-        else:
+                if selected_hour and minute != 0:
+                    label(hour, (inner + outer) / 2, str(minute), 9, "#ffffff" if active else INK)
+        outer_label_r = (BANDS[0][1] + BANDS[0][2]) / 2
+        for hour in range(24):
             all_on = all((hour, minute) in on for minute in (0, 15, 30, 45))
-            tx, ty = text_pos(hour, 24, (R_MID + R_OUT) / 2)
-            rdeg = rot(hour, 24)
-            parts.append(
-                f'<text x="{tx:.2f}" y="{ty + 3:.2f}" text-anchor="middle" font-size="11" '
-                f'font-weight="700" transform="rotate({rdeg:.2f} {tx:.2f} {ty + 3:.2f})" '
-                f'fill="{"#ffffff" if all_on else INK}">{pad(hour)}</text>'
-            )
+            label(hour, outer_label_r, pad(hour), 11, "#ffffff" if all_on else INK)
+    else:
+        rings = (
+            (0, (0, 15), R_MID, R_OUT),
+            (30, (30, 45), R_IN, R_MID),
+        )
+        for hour in range(24):
+            for pair, minutes, inner, outer in rings:
+                active = all((hour, minute) in on for minute in minutes)
+                fill = GREEN if active else (WHITE if pair == 0 else "#f8f9fa")
+                parts.append(
+                    f'<path d="{sector(hour, 24, inner, outer)}" fill="{fill}" '
+                    f'stroke="{STROKE}" stroke-width="1"/>'
+                )
+            hour_on = all((hour, minute) in on for minute in (0, 15))
+            half_on = all((hour, minute) in on for minute in (30, 45))
+            label(hour, (R_MID + R_OUT) / 2, f"{pad(hour)}:00", 11, "#ffffff" if hour_on else INK)
+            label(hour, (R_IN + R_MID) / 2, f"{pad(hour)}:30", 9, "#ffffff" if half_on else MUTED)
     if mode == 15:
         band = next(item for item in BANDS if item[0] == now_m)
         highlight = sector(now_h, 24, band[1], band[2])

--- a/images/preview.svg
+++ b/images/preview.svg
@@ -36,150 +36,102 @@
 <line x1="164.64" y1="164.64" x2="72.72" y2="72.72" stroke="#e5e7eb" stroke-width="1"/>
 <line x1="175.00" y1="156.70" x2="110.00" y2="44.12" stroke="#e5e7eb" stroke-width="1"/>
 <line x1="187.06" y1="151.70" x2="153.41" y2="26.13" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 200.00 52.50 L 200.00 20.00 A 180 180 0 0 1 246.59 26.13 L 238.18 57.53 A 147.5 147.5 0 0 0 200.00 52.50" fill="#ffffff" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 200.00 85.00 L 200.00 52.50 A 147.5 147.5 0 0 1 238.18 57.53 L 229.76 88.92 A 115 115 0 0 0 200.00 85.00" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 200.00 117.50 L 200.00 85.00 A 115 115 0 0 1 229.76 88.92 L 221.35 120.31 A 82.5 82.5 0 0 0 200.00 117.50" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 200.00 150.00 L 200.00 117.50 A 82.5 82.5 0 0 1 221.35 120.31 L 212.94 151.70 A 50 50 0 0 0 200.00 150.00" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 238.18 57.53 L 246.59 26.13 A 180 180 0 0 1 290.00 44.12 L 273.75 72.26 A 147.5 147.5 0 0 0 238.18 57.53" fill="#ffffff" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 229.76 88.92 L 238.18 57.53 A 147.5 147.5 0 0 1 273.75 72.26 L 257.50 100.41 A 115 115 0 0 0 229.76 88.92" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 221.35 120.31 L 229.76 88.92 A 115 115 0 0 1 257.50 100.41 L 241.25 128.55 A 82.5 82.5 0 0 0 221.35 120.31" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 212.94 151.70 L 221.35 120.31 A 82.5 82.5 0 0 1 241.25 128.55 L 225.00 156.70 A 50 50 0 0 0 212.94 151.70" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 273.75 72.26 L 290.00 44.12 A 180 180 0 0 1 327.28 72.72 L 304.30 95.70 A 147.5 147.5 0 0 0 273.75 72.26" fill="#ffffff" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 257.50 100.41 L 273.75 72.26 A 147.5 147.5 0 0 1 304.30 95.70 L 281.32 118.68 A 115 115 0 0 0 257.50 100.41" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 241.25 128.55 L 257.50 100.41 A 115 115 0 0 1 281.32 118.68 L 258.34 141.66 A 82.5 82.5 0 0 0 241.25 128.55" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 225.00 156.70 L 241.25 128.55 A 82.5 82.5 0 0 1 258.34 141.66 L 235.36 164.64 A 50 50 0 0 0 225.00 156.70" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 304.30 95.70 L 327.28 72.72 A 180 180 0 0 1 355.88 110.00 L 327.74 126.25 A 147.5 147.5 0 0 0 304.30 95.70" fill="#ffffff" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 281.32 118.68 L 304.30 95.70 A 147.5 147.5 0 0 1 327.74 126.25 L 299.59 142.50 A 115 115 0 0 0 281.32 118.68" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 258.34 141.66 L 281.32 118.68 A 115 115 0 0 1 299.59 142.50 L 271.45 158.75 A 82.5 82.5 0 0 0 258.34 141.66" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 235.36 164.64 L 258.34 141.66 A 82.5 82.5 0 0 1 271.45 158.75 L 243.30 175.00 A 50 50 0 0 0 235.36 164.64" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 327.74 126.25 L 355.88 110.00 A 180 180 0 0 1 373.87 153.41 L 342.47 161.82 A 147.5 147.5 0 0 0 327.74 126.25" fill="#ffffff" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 299.59 142.50 L 327.74 126.25 A 147.5 147.5 0 0 1 342.47 161.82 L 311.08 170.24 A 115 115 0 0 0 299.59 142.50" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 271.45 158.75 L 299.59 142.50 A 115 115 0 0 1 311.08 170.24 L 279.69 178.65 A 82.5 82.5 0 0 0 271.45 158.75" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 243.30 175.00 L 271.45 158.75 A 82.5 82.5 0 0 1 279.69 178.65 L 248.30 187.06 A 50 50 0 0 0 243.30 175.00" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 342.47 161.82 L 373.87 153.41 A 180 180 0 0 1 380.00 200.00 L 347.50 200.00 A 147.5 147.5 0 0 0 342.47 161.82" fill="#ffffff" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 311.08 170.24 L 342.47 161.82 A 147.5 147.5 0 0 1 347.50 200.00 L 315.00 200.00 A 115 115 0 0 0 311.08 170.24" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 279.69 178.65 L 311.08 170.24 A 115 115 0 0 1 315.00 200.00 L 282.50 200.00 A 82.5 82.5 0 0 0 279.69 178.65" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 248.30 187.06 L 279.69 178.65 A 82.5 82.5 0 0 1 282.50 200.00 L 250.00 200.00 A 50 50 0 0 0 248.30 187.06" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 347.50 200.00 L 380.00 200.00 A 180 180 0 0 1 373.87 246.59 L 342.47 238.18 A 147.5 147.5 0 0 0 347.50 200.00" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 315.00 200.00 L 347.50 200.00 A 147.5 147.5 0 0 1 342.47 238.18 L 311.08 229.76 A 115 115 0 0 0 315.00 200.00" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 282.50 200.00 L 315.00 200.00 A 115 115 0 0 1 311.08 229.76 L 279.69 221.35 A 82.5 82.5 0 0 0 282.50 200.00" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 250.00 200.00 L 282.50 200.00 A 82.5 82.5 0 0 1 279.69 221.35 L 248.30 212.94 A 50 50 0 0 0 250.00 200.00" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 342.47 238.18 L 373.87 246.59 A 180 180 0 0 1 355.88 290.00 L 327.74 273.75 A 147.5 147.5 0 0 0 342.47 238.18" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 311.08 229.76 L 342.47 238.18 A 147.5 147.5 0 0 1 327.74 273.75 L 299.59 257.50 A 115 115 0 0 0 311.08 229.76" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 279.69 221.35 L 311.08 229.76 A 115 115 0 0 1 299.59 257.50 L 271.45 241.25 A 82.5 82.5 0 0 0 279.69 221.35" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 248.30 212.94 L 279.69 221.35 A 82.5 82.5 0 0 1 271.45 241.25 L 243.30 225.00 A 50 50 0 0 0 248.30 212.94" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 327.74 273.75 L 355.88 290.00 A 180 180 0 0 1 327.28 327.28 L 304.30 304.30 A 147.5 147.5 0 0 0 327.74 273.75" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 299.59 257.50 L 327.74 273.75 A 147.5 147.5 0 0 1 304.30 304.30 L 281.32 281.32 A 115 115 0 0 0 299.59 257.50" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 271.45 241.25 L 299.59 257.50 A 115 115 0 0 1 281.32 281.32 L 258.34 258.34 A 82.5 82.5 0 0 0 271.45 241.25" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 243.30 225.00 L 271.45 241.25 A 82.5 82.5 0 0 1 258.34 258.34 L 235.36 235.36 A 50 50 0 0 0 243.30 225.00" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 304.30 304.30 L 327.28 327.28 A 180 180 0 0 1 290.00 355.88 L 273.75 327.74 A 147.5 147.5 0 0 0 304.30 304.30" fill="#ffffff" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 281.32 281.32 L 304.30 304.30 A 147.5 147.5 0 0 1 273.75 327.74 L 257.50 299.59 A 115 115 0 0 0 281.32 281.32" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 258.34 258.34 L 281.32 281.32 A 115 115 0 0 1 257.50 299.59 L 241.25 271.45 A 82.5 82.5 0 0 0 258.34 258.34" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 235.36 235.36 L 258.34 258.34 A 82.5 82.5 0 0 1 241.25 271.45 L 225.00 243.30 A 50 50 0 0 0 235.36 235.36" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 273.75 327.74 L 290.00 355.88 A 180 180 0 0 1 246.59 373.87 L 238.18 342.47 A 147.5 147.5 0 0 0 273.75 327.74" fill="#ffffff" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 257.50 299.59 L 273.75 327.74 A 147.5 147.5 0 0 1 238.18 342.47 L 229.76 311.08 A 115 115 0 0 0 257.50 299.59" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 241.25 271.45 L 257.50 299.59 A 115 115 0 0 1 229.76 311.08 L 221.35 279.69 A 82.5 82.5 0 0 0 241.25 271.45" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 225.00 243.30 L 241.25 271.45 A 82.5 82.5 0 0 1 221.35 279.69 L 212.94 248.30 A 50 50 0 0 0 225.00 243.30" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 238.18 342.47 L 246.59 373.87 A 180 180 0 0 1 200.00 380.00 L 200.00 347.50 A 147.5 147.5 0 0 0 238.18 342.47" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 229.76 311.08 L 238.18 342.47 A 147.5 147.5 0 0 1 200.00 347.50 L 200.00 315.00 A 115 115 0 0 0 229.76 311.08" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 221.35 279.69 L 229.76 311.08 A 115 115 0 0 1 200.00 315.00 L 200.00 282.50 A 82.5 82.5 0 0 0 221.35 279.69" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 212.94 248.30 L 221.35 279.69 A 82.5 82.5 0 0 1 200.00 282.50 L 200.00 250.00 A 50 50 0 0 0 212.94 248.30" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 200.00 347.50 L 200.00 380.00 A 180 180 0 0 1 153.41 373.87 L 161.82 342.47 A 147.5 147.5 0 0 0 200.00 347.50" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 200.00 315.00 L 200.00 347.50 A 147.5 147.5 0 0 1 161.82 342.47 L 170.24 311.08 A 115 115 0 0 0 200.00 315.00" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 200.00 282.50 L 200.00 315.00 A 115 115 0 0 1 170.24 311.08 L 178.65 279.69 A 82.5 82.5 0 0 0 200.00 282.50" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 200.00 250.00 L 200.00 282.50 A 82.5 82.5 0 0 1 178.65 279.69 L 187.06 248.30 A 50 50 0 0 0 200.00 250.00" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 161.82 342.47 L 153.41 373.87 A 180 180 0 0 1 110.00 355.88 L 126.25 327.74 A 147.5 147.5 0 0 0 161.82 342.47" fill="#ffffff" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 170.24 311.08 L 161.82 342.47 A 147.5 147.5 0 0 1 126.25 327.74 L 142.50 299.59 A 115 115 0 0 0 170.24 311.08" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 178.65 279.69 L 170.24 311.08 A 115 115 0 0 1 142.50 299.59 L 158.75 271.45 A 82.5 82.5 0 0 0 178.65 279.69" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 187.06 248.30 L 178.65 279.69 A 82.5 82.5 0 0 1 158.75 271.45 L 175.00 243.30 A 50 50 0 0 0 187.06 248.30" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 126.25 327.74 L 110.00 355.88 A 180 180 0 0 1 72.72 327.28 L 95.70 304.30 A 147.5 147.5 0 0 0 126.25 327.74" fill="#ffffff" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 142.50 299.59 L 126.25 327.74 A 147.5 147.5 0 0 1 95.70 304.30 L 118.68 281.32 A 115 115 0 0 0 142.50 299.59" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 158.75 271.45 L 142.50 299.59 A 115 115 0 0 1 118.68 281.32 L 141.66 258.34 A 82.5 82.5 0 0 0 158.75 271.45" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 175.00 243.30 L 158.75 271.45 A 82.5 82.5 0 0 1 141.66 258.34 L 164.64 235.36 A 50 50 0 0 0 175.00 243.30" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 95.70 304.30 L 72.72 327.28 A 180 180 0 0 1 44.12 290.00 L 72.26 273.75 A 147.5 147.5 0 0 0 95.70 304.30" fill="#ffffff" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 118.68 281.32 L 95.70 304.30 A 147.5 147.5 0 0 1 72.26 273.75 L 100.41 257.50 A 115 115 0 0 0 118.68 281.32" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 141.66 258.34 L 118.68 281.32 A 115 115 0 0 1 100.41 257.50 L 128.55 241.25 A 82.5 82.5 0 0 0 141.66 258.34" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 164.64 235.36 L 141.66 258.34 A 82.5 82.5 0 0 1 128.55 241.25 L 156.70 225.00 A 50 50 0 0 0 164.64 235.36" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 72.26 273.75 L 44.12 290.00 A 180 180 0 0 1 26.13 246.59 L 57.53 238.18 A 147.5 147.5 0 0 0 72.26 273.75" fill="#ffffff" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 100.41 257.50 L 72.26 273.75 A 147.5 147.5 0 0 1 57.53 238.18 L 88.92 229.76 A 115 115 0 0 0 100.41 257.50" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 128.55 241.25 L 100.41 257.50 A 115 115 0 0 1 88.92 229.76 L 120.31 221.35 A 82.5 82.5 0 0 0 128.55 241.25" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 156.70 225.00 L 128.55 241.25 A 82.5 82.5 0 0 1 120.31 221.35 L 151.70 212.94 A 50 50 0 0 0 156.70 225.00" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 57.53 238.18 L 26.13 246.59 A 180 180 0 0 1 20.00 200.00 L 52.50 200.00 A 147.5 147.5 0 0 0 57.53 238.18" fill="#ffffff" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 88.92 229.76 L 57.53 238.18 A 147.5 147.5 0 0 1 52.50 200.00 L 85.00 200.00 A 115 115 0 0 0 88.92 229.76" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 120.31 221.35 L 88.92 229.76 A 115 115 0 0 1 85.00 200.00 L 117.50 200.00 A 82.5 82.5 0 0 0 120.31 221.35" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 151.70 212.94 L 120.31 221.35 A 82.5 82.5 0 0 1 117.50 200.00 L 150.00 200.00 A 50 50 0 0 0 151.70 212.94" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 52.50 200.00 L 20.00 200.00 A 180 180 0 0 1 26.13 153.41 L 57.53 161.82 A 147.5 147.5 0 0 0 52.50 200.00" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 85.00 200.00 L 52.50 200.00 A 147.5 147.5 0 0 1 57.53 161.82 L 88.92 170.24 A 115 115 0 0 0 85.00 200.00" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 117.50 200.00 L 85.00 200.00 A 115 115 0 0 1 88.92 170.24 L 120.31 178.65 A 82.5 82.5 0 0 0 117.50 200.00" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 150.00 200.00 L 117.50 200.00 A 82.5 82.5 0 0 1 120.31 178.65 L 151.70 187.06 A 50 50 0 0 0 150.00 200.00" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 57.53 161.82 L 26.13 153.41 A 180 180 0 0 1 44.12 110.00 L 72.26 126.25 A 147.5 147.5 0 0 0 57.53 161.82" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 88.92 170.24 L 57.53 161.82 A 147.5 147.5 0 0 1 72.26 126.25 L 100.41 142.50 A 115 115 0 0 0 88.92 170.24" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 120.31 178.65 L 88.92 170.24 A 115 115 0 0 1 100.41 142.50 L 128.55 158.75 A 82.5 82.5 0 0 0 120.31 178.65" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 151.70 187.06 L 120.31 178.65 A 82.5 82.5 0 0 1 128.55 158.75 L 156.70 175.00 A 50 50 0 0 0 151.70 187.06" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 72.26 126.25 L 44.12 110.00 A 180 180 0 0 1 72.72 72.72 L 95.70 95.70 A 147.5 147.5 0 0 0 72.26 126.25" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 100.41 142.50 L 72.26 126.25 A 147.5 147.5 0 0 1 95.70 95.70 L 118.68 118.68 A 115 115 0 0 0 100.41 142.50" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 128.55 158.75 L 100.41 142.50 A 115 115 0 0 1 118.68 118.68 L 141.66 141.66 A 82.5 82.5 0 0 0 128.55 158.75" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 156.70 175.00 L 128.55 158.75 A 82.5 82.5 0 0 1 141.66 141.66 L 164.64 164.64 A 50 50 0 0 0 156.70 175.00" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 95.70 95.70 L 72.72 72.72 A 180 180 0 0 1 110.00 44.12 L 126.25 72.26 A 147.5 147.5 0 0 0 95.70 95.70" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 118.68 118.68 L 95.70 95.70 A 147.5 147.5 0 0 1 126.25 72.26 L 142.50 100.41 A 115 115 0 0 0 118.68 118.68" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 141.66 141.66 L 118.68 118.68 A 115 115 0 0 1 142.50 100.41 L 158.75 128.55 A 82.5 82.5 0 0 0 141.66 141.66" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 164.64 164.64 L 141.66 141.66 A 82.5 82.5 0 0 1 158.75 128.55 L 175.00 156.70 A 50 50 0 0 0 164.64 164.64" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 126.25 72.26 L 110.00 44.12 A 180 180 0 0 1 153.41 26.13 L 161.82 57.53 A 147.5 147.5 0 0 0 126.25 72.26" fill="#ffffff" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 142.50 100.41 L 126.25 72.26 A 147.5 147.5 0 0 1 161.82 57.53 L 170.24 88.92 A 115 115 0 0 0 142.50 100.41" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 158.75 128.55 L 142.50 100.41 A 115 115 0 0 1 170.24 88.92 L 178.65 120.31 A 82.5 82.5 0 0 0 158.75 128.55" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 175.00 156.70 L 158.75 128.55 A 82.5 82.5 0 0 1 178.65 120.31 L 187.06 151.70 A 50 50 0 0 0 175.00 156.70" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 161.82 57.53 L 153.41 26.13 A 180 180 0 0 1 200.00 20.00 L 200.00 52.50 A 147.5 147.5 0 0 0 161.82 57.53" fill="#ffffff" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 170.24 88.92 L 161.82 57.53 A 147.5 147.5 0 0 1 200.00 52.50 L 200.00 85.00 A 115 115 0 0 0 170.24 88.92" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 178.65 120.31 L 170.24 88.92 A 115 115 0 0 1 200.00 85.00 L 200.00 117.50 A 82.5 82.5 0 0 0 178.65 120.31" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
-<path d="M 187.06 151.70 L 178.65 120.31 A 82.5 82.5 0 0 1 200.00 117.50 L 200.00 150.00 A 50 50 0 0 0 187.06 151.70" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
-<text x="219.25" y="56.76" text-anchor="middle" font-size="11" font-weight="700" transform="rotate(-82.50 219.25 56.76)" fill="#374151">00:00</text>
-<text x="210.77" y="120.21" text-anchor="middle" font-size="9" font-weight="700" transform="rotate(-82.50 210.77 120.21)" fill="#6b7280">00:30</text>
-<text x="256.45" y="66.73" text-anchor="middle" font-size="11" font-weight="700" transform="rotate(-67.50 256.45 66.73)" fill="#374151">01:00</text>
-<text x="231.57" y="125.78" text-anchor="middle" font-size="9" font-weight="700" transform="rotate(-67.50 231.57 125.78)" fill="#6b7280">01:30</text>
-<text x="289.79" y="85.98" text-anchor="middle" font-size="11" font-weight="700" transform="rotate(-52.50 289.79 85.98)" fill="#374151">02:00</text>
-<text x="250.22" y="136.55" text-anchor="middle" font-size="9" font-weight="700" transform="rotate(-52.50 250.22 136.55)" fill="#6b7280">02:30</text>
-<text x="317.02" y="113.21" text-anchor="middle" font-size="11" font-weight="700" transform="rotate(-37.50 317.02 113.21)" fill="#374151">03:00</text>
-<text x="265.45" y="151.78" text-anchor="middle" font-size="9" font-weight="700" transform="rotate(-37.50 265.45 151.78)" fill="#6b7280">03:30</text>
-<text x="336.27" y="146.55" text-anchor="middle" font-size="11" font-weight="700" transform="rotate(-22.50 336.27 146.55)" fill="#374151">04:00</text>
-<text x="276.22" y="170.43" text-anchor="middle" font-size="9" font-weight="700" transform="rotate(-22.50 276.22 170.43)" fill="#6b7280">04:30</text>
-<text x="346.24" y="183.75" text-anchor="middle" font-size="11" font-weight="700" transform="rotate(-7.50 346.24 183.75)" fill="#374151">05:00</text>
-<text x="281.79" y="191.23" text-anchor="middle" font-size="9" font-weight="700" transform="rotate(-7.50 281.79 191.23)" fill="#6b7280">05:30</text>
-<text x="346.24" y="222.25" text-anchor="middle" font-size="11" font-weight="700" transform="rotate(7.50 346.24 222.25)" fill="#ffffff">06:00</text>
-<text x="281.79" y="212.77" text-anchor="middle" font-size="9" font-weight="700" transform="rotate(7.50 281.79 212.77)" fill="#ffffff">06:30</text>
-<text x="336.27" y="259.45" text-anchor="middle" font-size="11" font-weight="700" transform="rotate(22.50 336.27 259.45)" fill="#ffffff">07:00</text>
-<text x="276.22" y="233.57" text-anchor="middle" font-size="9" font-weight="700" transform="rotate(22.50 276.22 233.57)" fill="#ffffff">07:30</text>
-<text x="317.02" y="292.79" text-anchor="middle" font-size="11" font-weight="700" transform="rotate(37.50 317.02 292.79)" fill="#ffffff">08:00</text>
-<text x="265.45" y="252.22" text-anchor="middle" font-size="9" font-weight="700" transform="rotate(37.50 265.45 252.22)" fill="#ffffff">08:30</text>
-<text x="289.79" y="320.02" text-anchor="middle" font-size="11" font-weight="700" transform="rotate(52.50 289.79 320.02)" fill="#374151">09:00</text>
-<text x="250.22" y="267.45" text-anchor="middle" font-size="9" font-weight="700" transform="rotate(52.50 250.22 267.45)" fill="#6b7280">09:30</text>
-<text x="256.45" y="339.27" text-anchor="middle" font-size="11" font-weight="700" transform="rotate(67.50 256.45 339.27)" fill="#374151">10:00</text>
-<text x="231.57" y="278.22" text-anchor="middle" font-size="9" font-weight="700" transform="rotate(67.50 231.57 278.22)" fill="#6b7280">10:30</text>
-<text x="219.25" y="349.24" text-anchor="middle" font-size="11" font-weight="700" transform="rotate(82.50 219.25 349.24)" fill="#ffffff">11:00</text>
-<text x="210.77" y="283.79" text-anchor="middle" font-size="9" font-weight="700" transform="rotate(82.50 210.77 283.79)" fill="#ffffff">11:30</text>
-<text x="180.75" y="349.24" text-anchor="middle" font-size="11" font-weight="700" transform="rotate(277.50 180.75 349.24)" fill="#374151">12:00</text>
-<text x="189.23" y="283.79" text-anchor="middle" font-size="9" font-weight="700" transform="rotate(277.50 189.23 283.79)" fill="#6b7280">12:30</text>
-<text x="143.55" y="339.27" text-anchor="middle" font-size="11" font-weight="700" transform="rotate(292.50 143.55 339.27)" fill="#374151">13:00</text>
-<text x="168.43" y="278.22" text-anchor="middle" font-size="9" font-weight="700" transform="rotate(292.50 168.43 278.22)" fill="#6b7280">13:30</text>
-<text x="110.21" y="320.02" text-anchor="middle" font-size="11" font-weight="700" transform="rotate(307.50 110.21 320.02)" fill="#374151">14:00</text>
-<text x="149.78" y="267.45" text-anchor="middle" font-size="9" font-weight="700" transform="rotate(307.50 149.78 267.45)" fill="#6b7280">14:30</text>
-<text x="82.98" y="292.79" text-anchor="middle" font-size="11" font-weight="700" transform="rotate(322.50 82.98 292.79)" fill="#374151">15:00</text>
-<text x="134.55" y="252.22" text-anchor="middle" font-size="9" font-weight="700" transform="rotate(322.50 134.55 252.22)" fill="#6b7280">15:30</text>
-<text x="63.73" y="259.45" text-anchor="middle" font-size="11" font-weight="700" transform="rotate(337.50 63.73 259.45)" fill="#374151">16:00</text>
-<text x="123.78" y="233.57" text-anchor="middle" font-size="9" font-weight="700" transform="rotate(337.50 123.78 233.57)" fill="#6b7280">16:30</text>
-<text x="53.76" y="222.25" text-anchor="middle" font-size="11" font-weight="700" transform="rotate(352.50 53.76 222.25)" fill="#374151">17:00</text>
-<text x="118.21" y="212.77" text-anchor="middle" font-size="9" font-weight="700" transform="rotate(352.50 118.21 212.77)" fill="#6b7280">17:30</text>
-<text x="53.76" y="183.75" text-anchor="middle" font-size="11" font-weight="700" transform="rotate(367.50 53.76 183.75)" fill="#ffffff">18:00</text>
-<text x="118.21" y="191.23" text-anchor="middle" font-size="9" font-weight="700" transform="rotate(367.50 118.21 191.23)" fill="#ffffff">18:30</text>
-<text x="63.73" y="146.55" text-anchor="middle" font-size="11" font-weight="700" transform="rotate(382.50 63.73 146.55)" fill="#ffffff">19:00</text>
-<text x="123.78" y="170.43" text-anchor="middle" font-size="9" font-weight="700" transform="rotate(382.50 123.78 170.43)" fill="#ffffff">19:30</text>
-<text x="82.98" y="113.21" text-anchor="middle" font-size="11" font-weight="700" transform="rotate(397.50 82.98 113.21)" fill="#ffffff">20:00</text>
-<text x="134.55" y="151.78" text-anchor="middle" font-size="9" font-weight="700" transform="rotate(397.50 134.55 151.78)" fill="#ffffff">20:30</text>
-<text x="110.21" y="85.98" text-anchor="middle" font-size="11" font-weight="700" transform="rotate(412.50 110.21 85.98)" fill="#ffffff">21:00</text>
-<text x="149.78" y="136.55" text-anchor="middle" font-size="9" font-weight="700" transform="rotate(412.50 149.78 136.55)" fill="#ffffff">21:30</text>
-<text x="143.55" y="66.73" text-anchor="middle" font-size="11" font-weight="700" transform="rotate(427.50 143.55 66.73)" fill="#374151">22:00</text>
-<text x="168.43" y="125.78" text-anchor="middle" font-size="9" font-weight="700" transform="rotate(427.50 168.43 125.78)" fill="#6b7280">22:30</text>
-<text x="180.75" y="56.76" text-anchor="middle" font-size="11" font-weight="700" transform="rotate(442.50 180.75 56.76)" fill="#374151">23:00</text>
-<text x="189.23" y="120.21" text-anchor="middle" font-size="9" font-weight="700" transform="rotate(442.50 189.23 120.21)" fill="#6b7280">23:30</text>
+<path d="M 200.00 85.00 L 200.00 20.00 A 180 180 0 0 1 246.59 26.13 L 229.76 88.92 A 115 115 0 0 0 200.00 85.00" fill="#ffffff" stroke="#e5e7eb" stroke-width="1"/>
+<path d="M 200.00 150.00 L 200.00 85.00 A 115 115 0 0 1 229.76 88.92 L 212.94 151.70 A 50 50 0 0 0 200.00 150.00" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
+<text x="219.25" y="53.76" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="11" font-weight="700" transform="rotate(-82.50 219.25 53.76)" style="direction:ltr" fill="#374151">00:00</text>
+<text x="210.77" y="118.21" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="9" font-weight="700" transform="rotate(-82.50 210.77 118.21)" style="direction:ltr" fill="#6b7280">00:30</text>
+<path d="M 229.76 88.92 L 246.59 26.13 A 180 180 0 0 1 290.00 44.12 L 257.50 100.41 A 115 115 0 0 0 229.76 88.92" fill="#ffffff" stroke="#e5e7eb" stroke-width="1"/>
+<path d="M 212.94 151.70 L 229.76 88.92 A 115 115 0 0 1 257.50 100.41 L 225.00 156.70 A 50 50 0 0 0 212.94 151.70" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
+<text x="256.45" y="63.73" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="11" font-weight="700" transform="rotate(-67.50 256.45 63.73)" style="direction:ltr" fill="#374151">01:00</text>
+<text x="231.57" y="123.78" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="9" font-weight="700" transform="rotate(-67.50 231.57 123.78)" style="direction:ltr" fill="#6b7280">01:30</text>
+<path d="M 257.50 100.41 L 290.00 44.12 A 180 180 0 0 1 327.28 72.72 L 281.32 118.68 A 115 115 0 0 0 257.50 100.41" fill="#ffffff" stroke="#e5e7eb" stroke-width="1"/>
+<path d="M 225.00 156.70 L 257.50 100.41 A 115 115 0 0 1 281.32 118.68 L 235.36 164.64 A 50 50 0 0 0 225.00 156.70" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
+<text x="289.79" y="82.98" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="11" font-weight="700" transform="rotate(-52.50 289.79 82.98)" style="direction:ltr" fill="#374151">02:00</text>
+<text x="250.22" y="134.55" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="9" font-weight="700" transform="rotate(-52.50 250.22 134.55)" style="direction:ltr" fill="#6b7280">02:30</text>
+<path d="M 281.32 118.68 L 327.28 72.72 A 180 180 0 0 1 355.88 110.00 L 299.59 142.50 A 115 115 0 0 0 281.32 118.68" fill="#ffffff" stroke="#e5e7eb" stroke-width="1"/>
+<path d="M 235.36 164.64 L 281.32 118.68 A 115 115 0 0 1 299.59 142.50 L 243.30 175.00 A 50 50 0 0 0 235.36 164.64" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
+<text x="317.02" y="110.21" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="11" font-weight="700" transform="rotate(-37.50 317.02 110.21)" style="direction:ltr" fill="#374151">03:00</text>
+<text x="265.45" y="149.78" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="9" font-weight="700" transform="rotate(-37.50 265.45 149.78)" style="direction:ltr" fill="#6b7280">03:30</text>
+<path d="M 299.59 142.50 L 355.88 110.00 A 180 180 0 0 1 373.87 153.41 L 311.08 170.24 A 115 115 0 0 0 299.59 142.50" fill="#ffffff" stroke="#e5e7eb" stroke-width="1"/>
+<path d="M 243.30 175.00 L 299.59 142.50 A 115 115 0 0 1 311.08 170.24 L 248.30 187.06 A 50 50 0 0 0 243.30 175.00" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
+<text x="336.27" y="143.55" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="11" font-weight="700" transform="rotate(-22.50 336.27 143.55)" style="direction:ltr" fill="#374151">04:00</text>
+<text x="276.22" y="168.43" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="9" font-weight="700" transform="rotate(-22.50 276.22 168.43)" style="direction:ltr" fill="#6b7280">04:30</text>
+<path d="M 311.08 170.24 L 373.87 153.41 A 180 180 0 0 1 380.00 200.00 L 315.00 200.00 A 115 115 0 0 0 311.08 170.24" fill="#ffffff" stroke="#e5e7eb" stroke-width="1"/>
+<path d="M 248.30 187.06 L 311.08 170.24 A 115 115 0 0 1 315.00 200.00 L 250.00 200.00 A 50 50 0 0 0 248.30 187.06" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
+<text x="346.24" y="180.75" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="11" font-weight="700" transform="rotate(-7.50 346.24 180.75)" style="direction:ltr" fill="#374151">05:00</text>
+<text x="281.79" y="189.23" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="9" font-weight="700" transform="rotate(-7.50 281.79 189.23)" style="direction:ltr" fill="#6b7280">05:30</text>
+<path d="M 315.00 200.00 L 380.00 200.00 A 180 180 0 0 1 373.87 246.59 L 311.08 229.76 A 115 115 0 0 0 315.00 200.00" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
+<path d="M 250.00 200.00 L 315.00 200.00 A 115 115 0 0 1 311.08 229.76 L 248.30 212.94 A 50 50 0 0 0 250.00 200.00" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
+<text x="346.24" y="219.25" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="11" font-weight="700" transform="rotate(7.50 346.24 219.25)" style="direction:ltr" fill="#ffffff">06:00</text>
+<text x="281.79" y="210.77" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="9" font-weight="700" transform="rotate(7.50 281.79 210.77)" style="direction:ltr" fill="#ffffff">06:30</text>
+<path d="M 311.08 229.76 L 373.87 246.59 A 180 180 0 0 1 355.88 290.00 L 299.59 257.50 A 115 115 0 0 0 311.08 229.76" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
+<path d="M 248.30 212.94 L 311.08 229.76 A 115 115 0 0 1 299.59 257.50 L 243.30 225.00 A 50 50 0 0 0 248.30 212.94" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
+<text x="336.27" y="256.45" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="11" font-weight="700" transform="rotate(22.50 336.27 256.45)" style="direction:ltr" fill="#ffffff">07:00</text>
+<text x="276.22" y="231.57" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="9" font-weight="700" transform="rotate(22.50 276.22 231.57)" style="direction:ltr" fill="#ffffff">07:30</text>
+<path d="M 299.59 257.50 L 355.88 290.00 A 180 180 0 0 1 327.28 327.28 L 281.32 281.32 A 115 115 0 0 0 299.59 257.50" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
+<path d="M 243.30 225.00 L 299.59 257.50 A 115 115 0 0 1 281.32 281.32 L 235.36 235.36 A 50 50 0 0 0 243.30 225.00" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
+<text x="317.02" y="289.79" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="11" font-weight="700" transform="rotate(37.50 317.02 289.79)" style="direction:ltr" fill="#ffffff">08:00</text>
+<text x="265.45" y="250.22" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="9" font-weight="700" transform="rotate(37.50 265.45 250.22)" style="direction:ltr" fill="#ffffff">08:30</text>
+<path d="M 281.32 281.32 L 327.28 327.28 A 180 180 0 0 1 290.00 355.88 L 257.50 299.59 A 115 115 0 0 0 281.32 281.32" fill="#ffffff" stroke="#e5e7eb" stroke-width="1"/>
+<path d="M 235.36 235.36 L 281.32 281.32 A 115 115 0 0 1 257.50 299.59 L 225.00 243.30 A 50 50 0 0 0 235.36 235.36" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
+<text x="289.79" y="317.02" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="11" font-weight="700" transform="rotate(52.50 289.79 317.02)" style="direction:ltr" fill="#374151">09:00</text>
+<text x="250.22" y="265.45" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="9" font-weight="700" transform="rotate(52.50 250.22 265.45)" style="direction:ltr" fill="#6b7280">09:30</text>
+<path d="M 257.50 299.59 L 290.00 355.88 A 180 180 0 0 1 246.59 373.87 L 229.76 311.08 A 115 115 0 0 0 257.50 299.59" fill="#ffffff" stroke="#e5e7eb" stroke-width="1"/>
+<path d="M 225.00 243.30 L 257.50 299.59 A 115 115 0 0 1 229.76 311.08 L 212.94 248.30 A 50 50 0 0 0 225.00 243.30" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
+<text x="256.45" y="336.27" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="11" font-weight="700" transform="rotate(67.50 256.45 336.27)" style="direction:ltr" fill="#374151">10:00</text>
+<text x="231.57" y="276.22" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="9" font-weight="700" transform="rotate(67.50 231.57 276.22)" style="direction:ltr" fill="#6b7280">10:30</text>
+<path d="M 229.76 311.08 L 246.59 373.87 A 180 180 0 0 1 200.00 380.00 L 200.00 315.00 A 115 115 0 0 0 229.76 311.08" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
+<path d="M 212.94 248.30 L 229.76 311.08 A 115 115 0 0 1 200.00 315.00 L 200.00 250.00 A 50 50 0 0 0 212.94 248.30" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
+<text x="219.25" y="346.24" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="11" font-weight="700" transform="rotate(82.50 219.25 346.24)" style="direction:ltr" fill="#ffffff">11:00</text>
+<text x="210.77" y="281.79" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="9" font-weight="700" transform="rotate(82.50 210.77 281.79)" style="direction:ltr" fill="#ffffff">11:30</text>
+<path d="M 200.00 315.00 L 200.00 380.00 A 180 180 0 0 1 153.41 373.87 L 170.24 311.08 A 115 115 0 0 0 200.00 315.00" fill="#ffffff" stroke="#e5e7eb" stroke-width="1"/>
+<path d="M 200.00 250.00 L 200.00 315.00 A 115 115 0 0 1 170.24 311.08 L 187.06 248.30 A 50 50 0 0 0 200.00 250.00" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
+<text x="180.75" y="346.24" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="11" font-weight="700" transform="rotate(277.50 180.75 346.24)" style="direction:ltr" fill="#374151">12:00</text>
+<text x="189.23" y="281.79" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="9" font-weight="700" transform="rotate(277.50 189.23 281.79)" style="direction:ltr" fill="#6b7280">12:30</text>
+<path d="M 170.24 311.08 L 153.41 373.87 A 180 180 0 0 1 110.00 355.88 L 142.50 299.59 A 115 115 0 0 0 170.24 311.08" fill="#ffffff" stroke="#e5e7eb" stroke-width="1"/>
+<path d="M 187.06 248.30 L 170.24 311.08 A 115 115 0 0 1 142.50 299.59 L 175.00 243.30 A 50 50 0 0 0 187.06 248.30" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
+<text x="143.55" y="336.27" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="11" font-weight="700" transform="rotate(292.50 143.55 336.27)" style="direction:ltr" fill="#374151">13:00</text>
+<text x="168.43" y="276.22" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="9" font-weight="700" transform="rotate(292.50 168.43 276.22)" style="direction:ltr" fill="#6b7280">13:30</text>
+<path d="M 142.50 299.59 L 110.00 355.88 A 180 180 0 0 1 72.72 327.28 L 118.68 281.32 A 115 115 0 0 0 142.50 299.59" fill="#ffffff" stroke="#e5e7eb" stroke-width="1"/>
+<path d="M 175.00 243.30 L 142.50 299.59 A 115 115 0 0 1 118.68 281.32 L 164.64 235.36 A 50 50 0 0 0 175.00 243.30" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
+<text x="110.21" y="317.02" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="11" font-weight="700" transform="rotate(307.50 110.21 317.02)" style="direction:ltr" fill="#374151">14:00</text>
+<text x="149.78" y="265.45" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="9" font-weight="700" transform="rotate(307.50 149.78 265.45)" style="direction:ltr" fill="#6b7280">14:30</text>
+<path d="M 118.68 281.32 L 72.72 327.28 A 180 180 0 0 1 44.12 290.00 L 100.41 257.50 A 115 115 0 0 0 118.68 281.32" fill="#ffffff" stroke="#e5e7eb" stroke-width="1"/>
+<path d="M 164.64 235.36 L 118.68 281.32 A 115 115 0 0 1 100.41 257.50 L 156.70 225.00 A 50 50 0 0 0 164.64 235.36" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
+<text x="82.98" y="289.79" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="11" font-weight="700" transform="rotate(322.50 82.98 289.79)" style="direction:ltr" fill="#374151">15:00</text>
+<text x="134.55" y="250.22" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="9" font-weight="700" transform="rotate(322.50 134.55 250.22)" style="direction:ltr" fill="#6b7280">15:30</text>
+<path d="M 100.41 257.50 L 44.12 290.00 A 180 180 0 0 1 26.13 246.59 L 88.92 229.76 A 115 115 0 0 0 100.41 257.50" fill="#ffffff" stroke="#e5e7eb" stroke-width="1"/>
+<path d="M 156.70 225.00 L 100.41 257.50 A 115 115 0 0 1 88.92 229.76 L 151.70 212.94 A 50 50 0 0 0 156.70 225.00" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
+<text x="63.73" y="256.45" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="11" font-weight="700" transform="rotate(337.50 63.73 256.45)" style="direction:ltr" fill="#374151">16:00</text>
+<text x="123.78" y="231.57" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="9" font-weight="700" transform="rotate(337.50 123.78 231.57)" style="direction:ltr" fill="#6b7280">16:30</text>
+<path d="M 88.92 229.76 L 26.13 246.59 A 180 180 0 0 1 20.00 200.00 L 85.00 200.00 A 115 115 0 0 0 88.92 229.76" fill="#ffffff" stroke="#e5e7eb" stroke-width="1"/>
+<path d="M 151.70 212.94 L 88.92 229.76 A 115 115 0 0 1 85.00 200.00 L 150.00 200.00 A 50 50 0 0 0 151.70 212.94" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
+<text x="53.76" y="219.25" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="11" font-weight="700" transform="rotate(352.50 53.76 219.25)" style="direction:ltr" fill="#374151">17:00</text>
+<text x="118.21" y="210.77" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="9" font-weight="700" transform="rotate(352.50 118.21 210.77)" style="direction:ltr" fill="#6b7280">17:30</text>
+<path d="M 85.00 200.00 L 20.00 200.00 A 180 180 0 0 1 26.13 153.41 L 88.92 170.24 A 115 115 0 0 0 85.00 200.00" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
+<path d="M 150.00 200.00 L 85.00 200.00 A 115 115 0 0 1 88.92 170.24 L 151.70 187.06 A 50 50 0 0 0 150.00 200.00" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
+<text x="53.76" y="180.75" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="11" font-weight="700" transform="rotate(367.50 53.76 180.75)" style="direction:ltr" fill="#ffffff">18:00</text>
+<text x="118.21" y="189.23" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="9" font-weight="700" transform="rotate(367.50 118.21 189.23)" style="direction:ltr" fill="#ffffff">18:30</text>
+<path d="M 88.92 170.24 L 26.13 153.41 A 180 180 0 0 1 44.12 110.00 L 100.41 142.50 A 115 115 0 0 0 88.92 170.24" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
+<path d="M 151.70 187.06 L 88.92 170.24 A 115 115 0 0 1 100.41 142.50 L 156.70 175.00 A 50 50 0 0 0 151.70 187.06" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
+<text x="63.73" y="143.55" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="11" font-weight="700" transform="rotate(382.50 63.73 143.55)" style="direction:ltr" fill="#ffffff">19:00</text>
+<text x="123.78" y="168.43" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="9" font-weight="700" transform="rotate(382.50 123.78 168.43)" style="direction:ltr" fill="#ffffff">19:30</text>
+<path d="M 100.41 142.50 L 44.12 110.00 A 180 180 0 0 1 72.72 72.72 L 118.68 118.68 A 115 115 0 0 0 100.41 142.50" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
+<path d="M 156.70 175.00 L 100.41 142.50 A 115 115 0 0 1 118.68 118.68 L 164.64 164.64 A 50 50 0 0 0 156.70 175.00" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
+<text x="82.98" y="110.21" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="11" font-weight="700" transform="rotate(397.50 82.98 110.21)" style="direction:ltr" fill="#ffffff">20:00</text>
+<text x="134.55" y="149.78" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="9" font-weight="700" transform="rotate(397.50 134.55 149.78)" style="direction:ltr" fill="#ffffff">20:30</text>
+<path d="M 118.68 118.68 L 72.72 72.72 A 180 180 0 0 1 110.00 44.12 L 142.50 100.41 A 115 115 0 0 0 118.68 118.68" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
+<path d="M 164.64 164.64 L 118.68 118.68 A 115 115 0 0 1 142.50 100.41 L 175.00 156.70 A 50 50 0 0 0 164.64 164.64" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
+<text x="110.21" y="82.98" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="11" font-weight="700" transform="rotate(412.50 110.21 82.98)" style="direction:ltr" fill="#ffffff">21:00</text>
+<text x="149.78" y="134.55" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="9" font-weight="700" transform="rotate(412.50 149.78 134.55)" style="direction:ltr" fill="#ffffff">21:30</text>
+<path d="M 142.50 100.41 L 110.00 44.12 A 180 180 0 0 1 153.41 26.13 L 170.24 88.92 A 115 115 0 0 0 142.50 100.41" fill="#ffffff" stroke="#e5e7eb" stroke-width="1"/>
+<path d="M 175.00 156.70 L 142.50 100.41 A 115 115 0 0 1 170.24 88.92 L 187.06 151.70 A 50 50 0 0 0 175.00 156.70" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
+<text x="143.55" y="63.73" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="11" font-weight="700" transform="rotate(427.50 143.55 63.73)" style="direction:ltr" fill="#374151">22:00</text>
+<text x="168.43" y="123.78" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="9" font-weight="700" transform="rotate(427.50 168.43 123.78)" style="direction:ltr" fill="#6b7280">22:30</text>
+<path d="M 170.24 88.92 L 153.41 26.13 A 180 180 0 0 1 200.00 20.00 L 200.00 85.00 A 115 115 0 0 0 170.24 88.92" fill="#ffffff" stroke="#e5e7eb" stroke-width="1"/>
+<path d="M 187.06 151.70 L 170.24 88.92 A 115 115 0 0 1 200.00 85.00 L 200.00 150.00 A 50 50 0 0 0 187.06 151.70" fill="#f8f9fa" stroke="#e5e7eb" stroke-width="1"/>
+<text x="180.75" y="53.76" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="11" font-weight="700" transform="rotate(442.50 180.75 53.76)" style="direction:ltr" fill="#374151">23:00</text>
+<text x="189.23" y="118.21" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="9" font-weight="700" transform="rotate(442.50 189.23 118.21)" style="direction:ltr" fill="#6b7280">23:30</text>
 <path d="M 142.50 299.59 L 110.00 355.88 A 180 180 0 0 1 72.72 327.28 L 118.68 281.32 A 115 115 0 0 0 142.50 299.59" fill="none" stroke="#ff6b6b" stroke-width="5" stroke-linejoin="round"/>
 <circle cx="200" cy="200" r="50" fill="#10b981"/>
 <text x="200" y="205" text-anchor="middle" font-size="16" font-weight="700" fill="#fff">ON</text>
@@ -271,11 +223,11 @@
 <path d="M 212.94 248.30 L 221.35 279.69 A 82.5 82.5 0 0 1 200.00 282.50 L 200.00 250.00 A 50 50 0 0 0 212.94 248.30" fill="#10b981" stroke="#e5e7eb" stroke-width="1"/>
 <path d="M 200.00 347.50 L 200.00 380.00 A 180 180 0 0 1 153.41 373.87 L 161.82 342.47 A 147.5 147.5 0 0 0 200.00 347.50" fill="#10b981" stroke="#3b82f6" stroke-width="2.5"/>
 <path d="M 200.00 315.00 L 200.00 347.50 A 147.5 147.5 0 0 1 161.82 342.47 L 170.24 311.08 A 115 115 0 0 0 200.00 315.00" fill="#ffffff" stroke="#3b82f6" stroke-width="2.5"/>
-<text x="182.87" y="332.13" text-anchor="middle" font-size="9" font-weight="700" transform="rotate(277.50 182.87 332.13)" fill="#374151">15</text>
+<text x="182.87" y="330.13" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="9" font-weight="700" transform="rotate(277.50 182.87 330.13)" style="direction:ltr" fill="#374151">15</text>
 <path d="M 200.00 282.50 L 200.00 315.00 A 115 115 0 0 1 170.24 311.08 L 178.65 279.69 A 82.5 82.5 0 0 0 200.00 282.50" fill="#10b981" stroke="#3b82f6" stroke-width="2.5"/>
-<text x="187.11" y="299.91" text-anchor="middle" font-size="9" font-weight="700" transform="rotate(277.50 187.11 299.91)" fill="#ffffff">30</text>
+<text x="187.11" y="297.91" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="9" font-weight="700" transform="rotate(277.50 187.11 297.91)" style="direction:ltr" fill="#ffffff">30</text>
 <path d="M 200.00 250.00 L 200.00 282.50 A 82.5 82.5 0 0 1 178.65 279.69 L 187.06 248.30 A 50 50 0 0 0 200.00 250.00" fill="#ffffff" stroke="#3b82f6" stroke-width="2.5"/>
-<text x="191.35" y="267.68" text-anchor="middle" font-size="9" font-weight="700" transform="rotate(277.50 191.35 267.68)" fill="#374151">45</text>
+<text x="191.35" y="265.68" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="9" font-weight="700" transform="rotate(277.50 191.35 265.68)" style="direction:ltr" fill="#374151">45</text>
 <path d="M 161.82 342.47 L 153.41 373.87 A 180 180 0 0 1 110.00 355.88 L 126.25 327.74 A 147.5 147.5 0 0 0 161.82 342.47" fill="#ffffff" stroke="#e5e7eb" stroke-width="1"/>
 <path d="M 170.24 311.08 L 161.82 342.47 A 147.5 147.5 0 0 1 126.25 327.74 L 142.50 299.59 A 115 115 0 0 0 170.24 311.08" fill="#ffffff" stroke="#e5e7eb" stroke-width="1"/>
 <path d="M 178.65 279.69 L 170.24 311.08 A 115 115 0 0 1 142.50 299.59 L 158.75 271.45 A 82.5 82.5 0 0 0 178.65 279.69" fill="#ffffff" stroke="#e5e7eb" stroke-width="1"/>
@@ -320,30 +272,30 @@
 <path d="M 170.24 88.92 L 161.82 57.53 A 147.5 147.5 0 0 1 200.00 52.50 L 200.00 85.00 A 115 115 0 0 0 170.24 88.92" fill="#ffffff" stroke="#e5e7eb" stroke-width="1"/>
 <path d="M 178.65 120.31 L 170.24 88.92 A 115 115 0 0 1 200.00 85.00 L 200.00 117.50 A 82.5 82.5 0 0 0 178.65 120.31" fill="#ffffff" stroke="#e5e7eb" stroke-width="1"/>
 <path d="M 187.06 151.70 L 178.65 120.31 A 82.5 82.5 0 0 1 200.00 117.50 L 200.00 150.00 A 50 50 0 0 0 187.06 151.70" fill="#ffffff" stroke="#e5e7eb" stroke-width="1"/>
-<text x="219.25" y="56.76" text-anchor="middle" font-size="11" font-weight="700" transform="rotate(-82.50 219.25 56.76)" fill="#374151">00</text>
-<text x="256.45" y="66.73" text-anchor="middle" font-size="11" font-weight="700" transform="rotate(-67.50 256.45 66.73)" fill="#374151">01</text>
-<text x="289.79" y="85.98" text-anchor="middle" font-size="11" font-weight="700" transform="rotate(-52.50 289.79 85.98)" fill="#374151">02</text>
-<text x="317.02" y="113.21" text-anchor="middle" font-size="11" font-weight="700" transform="rotate(-37.50 317.02 113.21)" fill="#374151">03</text>
-<text x="336.27" y="146.55" text-anchor="middle" font-size="11" font-weight="700" transform="rotate(-22.50 336.27 146.55)" fill="#374151">04</text>
-<text x="346.24" y="183.75" text-anchor="middle" font-size="11" font-weight="700" transform="rotate(-7.50 346.24 183.75)" fill="#374151">05</text>
-<text x="346.24" y="222.25" text-anchor="middle" font-size="11" font-weight="700" transform="rotate(7.50 346.24 222.25)" fill="#ffffff">06</text>
-<text x="336.27" y="259.45" text-anchor="middle" font-size="11" font-weight="700" transform="rotate(22.50 336.27 259.45)" fill="#ffffff">07</text>
-<text x="317.02" y="292.79" text-anchor="middle" font-size="11" font-weight="700" transform="rotate(37.50 317.02 292.79)" fill="#ffffff">08</text>
-<text x="289.79" y="320.02" text-anchor="middle" font-size="11" font-weight="700" transform="rotate(52.50 289.79 320.02)" fill="#374151">09</text>
-<text x="256.45" y="339.27" text-anchor="middle" font-size="11" font-weight="700" transform="rotate(67.50 256.45 339.27)" fill="#374151">10</text>
-<text x="219.25" y="349.24" text-anchor="middle" font-size="11" font-weight="700" transform="rotate(82.50 219.25 349.24)" fill="#ffffff">11</text>
-<text x="180.75" y="349.24" text-anchor="middle" font-size="11" font-weight="700" transform="rotate(277.50 180.75 349.24)" fill="#374151">12</text>
-<text x="143.55" y="339.27" text-anchor="middle" font-size="11" font-weight="700" transform="rotate(292.50 143.55 339.27)" fill="#374151">13</text>
-<text x="110.21" y="320.02" text-anchor="middle" font-size="11" font-weight="700" transform="rotate(307.50 110.21 320.02)" fill="#374151">14</text>
-<text x="82.98" y="292.79" text-anchor="middle" font-size="11" font-weight="700" transform="rotate(322.50 82.98 292.79)" fill="#374151">15</text>
-<text x="63.73" y="259.45" text-anchor="middle" font-size="11" font-weight="700" transform="rotate(337.50 63.73 259.45)" fill="#374151">16</text>
-<text x="53.76" y="222.25" text-anchor="middle" font-size="11" font-weight="700" transform="rotate(352.50 53.76 222.25)" fill="#374151">17</text>
-<text x="53.76" y="183.75" text-anchor="middle" font-size="11" font-weight="700" transform="rotate(367.50 53.76 183.75)" fill="#ffffff">18</text>
-<text x="63.73" y="146.55" text-anchor="middle" font-size="11" font-weight="700" transform="rotate(382.50 63.73 146.55)" fill="#ffffff">19</text>
-<text x="82.98" y="113.21" text-anchor="middle" font-size="11" font-weight="700" transform="rotate(397.50 82.98 113.21)" fill="#ffffff">20</text>
-<text x="110.21" y="85.98" text-anchor="middle" font-size="11" font-weight="700" transform="rotate(412.50 110.21 85.98)" fill="#ffffff">21</text>
-<text x="143.55" y="66.73" text-anchor="middle" font-size="11" font-weight="700" transform="rotate(427.50 143.55 66.73)" fill="#374151">22</text>
-<text x="180.75" y="56.76" text-anchor="middle" font-size="11" font-weight="700" transform="rotate(442.50 180.75 56.76)" fill="#374151">23</text>
+<text x="221.37" y="37.65" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="11" font-weight="700" transform="rotate(-82.50 221.37 37.65)" style="direction:ltr" fill="#374151">00</text>
+<text x="262.66" y="48.71" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="11" font-weight="700" transform="rotate(-67.50 262.66 48.71)" style="direction:ltr" fill="#374151">01</text>
+<text x="299.68" y="70.09" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="11" font-weight="700" transform="rotate(-52.50 299.68 70.09)" style="direction:ltr" fill="#374151">02</text>
+<text x="329.91" y="100.32" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="11" font-weight="700" transform="rotate(-37.50 329.91 100.32)" style="direction:ltr" fill="#374151">03</text>
+<text x="351.29" y="137.34" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="11" font-weight="700" transform="rotate(-22.50 351.29 137.34)" style="direction:ltr" fill="#374151">04</text>
+<text x="362.35" y="178.63" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="11" font-weight="700" transform="rotate(-7.50 362.35 178.63)" style="direction:ltr" fill="#374151">05</text>
+<text x="362.35" y="221.37" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="11" font-weight="700" transform="rotate(7.50 362.35 221.37)" style="direction:ltr" fill="#ffffff">06</text>
+<text x="351.29" y="262.66" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="11" font-weight="700" transform="rotate(22.50 351.29 262.66)" style="direction:ltr" fill="#ffffff">07</text>
+<text x="329.91" y="299.68" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="11" font-weight="700" transform="rotate(37.50 329.91 299.68)" style="direction:ltr" fill="#ffffff">08</text>
+<text x="299.68" y="329.91" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="11" font-weight="700" transform="rotate(52.50 299.68 329.91)" style="direction:ltr" fill="#374151">09</text>
+<text x="262.66" y="351.29" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="11" font-weight="700" transform="rotate(67.50 262.66 351.29)" style="direction:ltr" fill="#374151">10</text>
+<text x="221.37" y="362.35" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="11" font-weight="700" transform="rotate(82.50 221.37 362.35)" style="direction:ltr" fill="#ffffff">11</text>
+<text x="178.63" y="362.35" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="11" font-weight="700" transform="rotate(277.50 178.63 362.35)" style="direction:ltr" fill="#374151">12</text>
+<text x="137.34" y="351.29" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="11" font-weight="700" transform="rotate(292.50 137.34 351.29)" style="direction:ltr" fill="#374151">13</text>
+<text x="100.32" y="329.91" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="11" font-weight="700" transform="rotate(307.50 100.32 329.91)" style="direction:ltr" fill="#374151">14</text>
+<text x="70.09" y="299.68" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="11" font-weight="700" transform="rotate(322.50 70.09 299.68)" style="direction:ltr" fill="#374151">15</text>
+<text x="48.71" y="262.66" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="11" font-weight="700" transform="rotate(337.50 48.71 262.66)" style="direction:ltr" fill="#374151">16</text>
+<text x="37.65" y="221.37" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="11" font-weight="700" transform="rotate(352.50 37.65 221.37)" style="direction:ltr" fill="#374151">17</text>
+<text x="37.65" y="178.63" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="11" font-weight="700" transform="rotate(367.50 37.65 178.63)" style="direction:ltr" fill="#ffffff">18</text>
+<text x="48.71" y="137.34" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="11" font-weight="700" transform="rotate(382.50 48.71 137.34)" style="direction:ltr" fill="#ffffff">19</text>
+<text x="70.09" y="100.32" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="11" font-weight="700" transform="rotate(397.50 70.09 100.32)" style="direction:ltr" fill="#ffffff">20</text>
+<text x="100.32" y="70.09" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="11" font-weight="700" transform="rotate(412.50 100.32 70.09)" style="direction:ltr" fill="#ffffff">21</text>
+<text x="137.34" y="48.71" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="11" font-weight="700" transform="rotate(427.50 137.34 48.71)" style="direction:ltr" fill="#374151">22</text>
+<text x="178.63" y="37.65" text-anchor="middle" dominant-baseline="central" alignment-baseline="middle" font-size="11" font-weight="700" transform="rotate(442.50 178.63 37.65)" style="direction:ltr" fill="#374151">23</text>
 <path d="M 126.25 327.74 L 110.00 355.88 A 180 180 0 0 1 72.72 327.28 L 95.70 304.30 A 147.5 147.5 0 0 0 126.25 327.74" fill="none" stroke="#ff6b6b" stroke-width="4" stroke-linejoin="round"/>
 <circle cx="200" cy="200" r="50" fill="#10b981"/>
 <text x="200" y="205" text-anchor="middle" font-size="16" font-weight="700" fill="#fff">ON</text>


### PR DESCRIPTION
Place 15-minute hour numbers in the outer band (same as v1.3.0 card) and draw the 30-minute preview with two rings only.